### PR TITLE
Add support for LDAP filters and attribute search

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -136,7 +136,7 @@ class Server {
         } elseif ($this->authType === 'Apache') {
             $authBackend = new \Sabre\DAV\Auth\Backend\Apache();
         } elseif ($this->authType === 'LDAP') {
-            $authBackend = new \Baikal\Core\LDAP($this->pdo, 'users', $config['system']['ldap_uri'], $config['system']['ldap_dn'], $config['system']['ldap_cn'], $config['system']['ldap_mail']);
+            $authBackend = new \Baikal\Core\LDAP($this->pdo, 'users', $config['system']['ldap_mode'], $config['system']['ldap_uri'], $config['system']['ldap_bind_dn'], $config['system']['ldap_bind_password'], $config['system']['ldap_dn'], $config['system']['ldap_cn'], $config['system']['ldap_mail'], $config['system']['ldap_search_base'], $config['system']['ldap_search_attribute'], $config['system']['ldap_search_filter']);
         } else {
             $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
             $authBackend->setRealm($this->authRealm);

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -37,10 +37,16 @@ class Standard extends \Baikal\Model\Config {
         "card_enabled"           => true,
         "cal_enabled"            => true,
         "dav_auth_type"          => "Digest",
+        "ldap_mode"              => "None",
         "ldap_uri"               => "ldap://127.0.0.1",
+        "ldap_bind_dn"           => "cn=baikal,ou=apps,dc=example,dc=com",
+        "ldap_bind_password"     => "",
         "ldap_dn"                => "mail=%u",
         "ldap_cn"                => "cn",
         "ldap_mail"              => "mail",
+        "ldap_search_base"       => "ou=users,dc=example,dc=com",
+        "ldap_search_attribute"  => "uid=%U",
+        "ldap_search_filter"     => "(objectClass=*)",
         "use_smtp"               => false,
         "smtp_username"          => "",
         "smtp_password"          => "",
@@ -116,9 +122,25 @@ class Standard extends \Baikal\Model\Config {
             "options" => ["Digest", "Basic", "Apache", "LDAP"],
         ]));
 
+        $oMorpho->add(new \Formal\Element\Listbox([
+            "prop"    => "ldap_mode",
+            "label"   => "LDAP authentication mode",
+            "options" => ["DN", "Attribute", "Filter"],
+        ]));
+
         $oMorpho->add(new \Formal\Element\Text([
             "prop"    => "ldap_uri",
             "label"   => "URI of the LDAP server; default ldap://127.0.0.1",
+        ]));
+
+        $oMorpho->add(new \Formal\Element\Text([
+            "prop"    => "ldap_bind_dn",
+            "label"   => "DN which Baikal will use to bind to the LDAP server",
+        ]));
+
+        $oMorpho->add(new \Formal\Element\Password([
+            "prop"    => "ldap_bind_password",
+            "label"   => "The password of the bind DN user",
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
@@ -134,6 +156,22 @@ class Standard extends \Baikal\Model\Config {
         $oMorpho->add(new \Formal\Element\Text([
             "prop"    => "ldap_mail",
             "label"   => "LDAP-attribute for email; default mail",
+        ]));
+
+        $oMorpho->add(new \Formal\Element\Text([
+            "prop"    => "ldap_search_base",
+            "label"   => "The base of the LDAP search",
+        ]));
+
+
+        $oMorpho->add(new \Formal\Element\Text([
+            "prop"    => "ldap_search_attribute",
+            "label"   => "Attribute and match.; with replacments %u => username, %U => user part, %d => domain part of username, %1-9 parts of the domain in reverse order",
+        ]));
+
+        $oMorpho->add(new \Formal\Element\Text([
+            "prop"    => "ldap_search_filter",
+            "label"   => "The LDAP filter to be applied to the search.",
         ]));
 
         $oMorpho->add(new \Formal\Element\Password([

--- a/Core/Frameworks/BaikalAdmin/Resources/main.js
+++ b/Core/Frameworks/BaikalAdmin/Resources/main.js
@@ -36,8 +36,11 @@ function hideDepends(el, dep, val) {
     if(typeof(val) == "boolean"){
         if(el_dep.checked == val)
             visibility = "block";
-    } else {
+    } else if (typeof(val) == string) {
         if(el_dep.value == val)
+            visibility = "block";
+    } else {
+        if(val.includes(el_dep.value))
             visibility = "block";
     }
     el_tohide.style.display = visibility;
@@ -48,10 +51,16 @@ hideDependsArray=[
     ["control-group-smtp_password", "use_smtp", true],
     ["control-group-smtp_host", "use_smtp", true],
     ["control-group-smtp_port", "use_smtp", true],
+    ["control-group-ldap_mode", "dav_auth_type", "LDAP"],
     ["control-group-ldap_uri", "dav_auth_type", "LDAP"],
-    ["control-group-ldap_dn", "dav_auth_type", "LDAP"],
     ["control-group-ldap_cn", "dav_auth_type", "LDAP"],
     ["control-group-ldap_mail", "dav_auth_type", "LDAP"],
+    ["control-group-ldap_dn", "ldap_mode", "DN"],
+    ["control-group-ldap_bind_dn", "ldap_mode", ["Attribute", "Filter"]],
+    ["control-group-ldap_bind_password", "ldap_mode", ["Attribute", "Filter"]],
+    ["control-group-ldap_search_base", "ldap_mode", ["Attribute", "Filter"]],
+    ["control-group-ldap_search_attribute", "ldap_mode", "Attribute"],
+    ["control-group-ldap_search_filter", "ldap_mode", "Filter"],
 ];
 
 function hideDependsAll() {


### PR DESCRIPTION
This commit adds support for LDAP filters and attribute searching.

Note that this commit uses the same field hiding system used in the last commit, so an additional commit will have to be made to comply with [this comment](https://github.com/sabre-io/Baikal/pull/1119#issuecomment-1186179014).